### PR TITLE
feat(86c21muv6 & 86c23cp42): implement tags and comments modules

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { QuestionsModule } from './questions/questions.module';
 import { IdentificationRequestsModule } from './identification-requests/identification-requests.module';
 import { DashboardAccountModule } from './dashboard-accounts/dashboard-accounts.module';
 import { VotesModule } from './votes/votes.module';
+import { CommentsModule } from './comments/comments.module';
 
 /**
  * Module principal de l'application
@@ -47,7 +48,8 @@ import { VotesModule } from './votes/votes.module';
     IdentificationRequestsModule,
     DashboardAccountModule,
     VotesModule,
-    ReportsModule
+    ReportsModule,
+    CommentsModule
   ],
   controllers: [],
   providers: [],

--- a/src/comments/comments.controller.spec.ts
+++ b/src/comments/comments.controller.spec.ts
@@ -1,0 +1,158 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentsController } from './comments.controller';
+import { CommentsService } from './comments.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+import { Comment } from './entities/comment.entity';
+import { NotFoundException } from '@nestjs/common';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Member } from '../members/entities/member.entity';
+import { Guild } from '../guilds/entities/guild.entity';
+
+describe('CommentsController', () => {
+  let controller: CommentsController;
+  let service: CommentsService;
+
+  // Mock des données de test
+  const mockGuild: Guild = {
+    uuid: '123e4567-e89b-12d3-a456-426614174002',
+    name: 'Test Guild',
+    memberCount: 1,
+    configuration: {},
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+
+  const mockMember: Member = {
+    uuid: '123e4567-e89b-12d3-a456-426614174001',
+    guild_username: 'TestUser',
+    xp: '100.00',
+    level: 1,
+    community_role: 'Member',
+    status: 'Active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    uuid_guild: '123e4567-e89b-12d3-a456-426614174002',
+    uuid_discord: '123456789',
+    guild: mockGuild
+  };
+
+  const mockComment: Comment = {
+    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    content: 'Test comment',
+    comment_status: 'active',
+    createdAt: new Date(),
+    uuid_member: '123e4567-e89b-12d3-a456-426614174001',
+    resource_uuid: '123e4567-e89b-12d3-a456-426614174002',
+    user_uuid: '123e4567-e89b-12d3-a456-426614174003',
+    member: mockMember
+  };
+
+  const mockCreateDto: CreateCommentDto = {
+    content: 'Test comment',
+    comment_status: 'active',
+    uuid_member: '123e4567-e89b-12d3-a456-426614174001',
+    resource_uuid: '123e4567-e89b-12d3-a456-426614174002',
+    user_uuid: '123e4567-e89b-12d3-a456-426614174003'
+  };
+
+  const mockUpdateDto: UpdateCommentDto = {
+    content: 'Updated test comment',
+    comment_status: 'inactive'
+  };
+
+  const mockCommentsService = {
+    create: vi.fn(),
+    findAll: vi.fn(),
+    findOne: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommentsController],
+      providers: [
+        {
+          provide: CommentsService,
+          useValue: mockCommentsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CommentsController>(CommentsController);
+    service = module.get<CommentsService>(CommentsService);
+  });
+
+  describe('create', () => {
+    it('devrait créer un nouveau commentaire', async () => {
+      mockCommentsService.create.mockResolvedValue(mockComment);
+
+      const result = await controller.create(mockCreateDto);
+
+      expect(result).toEqual(mockComment);
+      expect(mockCommentsService.create).toHaveBeenCalledWith(mockCreateDto);
+    });
+  });
+
+  describe('findAll', () => {
+    it('devrait retourner un tableau de commentaires', async () => {
+      mockCommentsService.findAll.mockResolvedValue([mockComment]);
+
+      const result = await controller.findAll();
+
+      expect(result).toEqual([mockComment]);
+      expect(mockCommentsService.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    it('devrait retourner un commentaire par uuid', async () => {
+      mockCommentsService.findOne.mockResolvedValue(mockComment);
+
+      const result = await controller.findOne(mockComment.uuid);
+
+      expect(result).toEqual(mockComment);
+      expect(mockCommentsService.findOne).toHaveBeenCalledWith(mockComment.uuid);
+    });
+
+    it('devrait lever une exception si le commentaire n\'est pas trouvé', async () => {
+      mockCommentsService.findOne.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.findOne('non-existant')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('devrait mettre à jour un commentaire', async () => {
+      mockCommentsService.update.mockResolvedValue({ ...mockComment, ...mockUpdateDto });
+
+      const result = await controller.update(mockComment.uuid, mockUpdateDto);
+
+      expect(result).toEqual({ ...mockComment, ...mockUpdateDto });
+      expect(mockCommentsService.update).toHaveBeenCalledWith(mockComment.uuid, mockUpdateDto);
+    });
+
+    it('devrait lever une exception si le commentaire à mettre à jour n\'existe pas', async () => {
+      mockCommentsService.update.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.update('non-existant', { content: 'test' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('devrait supprimer un commentaire', async () => {
+      mockCommentsService.remove.mockResolvedValue(undefined);
+
+      await controller.remove(mockComment.uuid);
+
+      expect(mockCommentsService.remove).toHaveBeenCalledWith(mockComment.uuid);
+    });
+
+    it('devrait lever une exception si le commentaire à supprimer n\'existe pas', async () => {
+      mockCommentsService.remove.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.remove('non-existant')).rejects.toThrow(NotFoundException);
+    });
+  });
+}); 

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, HttpCode, HttpStatus, ParseUUIDPipe } from '@nestjs/common';
+import { CommentsService } from './comments.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+import { Comment } from './entities/comment.entity';
+
+@Controller('comments')
+export class CommentsController {
+  constructor(private readonly commentsService: CommentsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() createCommentDto: CreateCommentDto): Promise<Comment> {
+    return this.commentsService.create(createCommentDto);
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  findAll(): Promise<Comment[]> {
+    return this.commentsService.findAll();
+  }
+
+  @Get(':uuid')
+  @HttpCode(HttpStatus.OK)
+  findOne(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<Comment> {
+    return this.commentsService.findOne(uuid);
+  }
+
+  @Patch(':uuid')
+  @HttpCode(HttpStatus.OK)
+  update(
+    @Param('uuid', ParseUUIDPipe) uuid: string, 
+    @Body() updateCommentDto: UpdateCommentDto
+  ): Promise<Comment> {
+    return this.commentsService.update(uuid, updateCommentDto);
+  }
+
+  @Delete(':uuid')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<void> {
+    return this.commentsService.remove(uuid);
+  }
+}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CommentsService } from './comments.service';
+import { CommentsController } from './comments.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Comment } from './entities/comment.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Comment])],
+  controllers: [CommentsController],
+  providers: [CommentsService],
+  exports: [CommentsService]
+})
+export class CommentsModule {}

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentsService } from './comments.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Comment } from './entities/comment.entity';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('CommentsService', () => {
+  let service: CommentsService;
+  let repository: Repository<Comment>;
+
+  const mockComment = {
+    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    content: 'Test comment',
+    member: { uuid: '123', username: 'testUser' }
+  };
+
+  const mockRepository = {
+    create: vi.fn(),
+    save: vi.fn(),
+    find: vi.fn(),
+    findOne: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentsService,
+        {
+          provide: getRepositoryToken(Comment),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CommentsService>(CommentsService);
+    repository = module.get<Repository<Comment>>(getRepositoryToken(Comment));
+  });
+
+  describe('create', () => {
+    it('devrait créer un nouveau commentaire', async () => {
+      const createCommentDto: CreateCommentDto = {
+        content: 'Test comment',
+        comment_status: 'active',
+        uuid_member: '123',
+        resource_uuid: '123e4567-e89b-12d3-a456-426614174000',
+        user_uuid: '123e4567-e89b-12d3-a456-426614174000'
+      };
+
+      mockRepository.create.mockReturnValue(mockComment);
+      mockRepository.save.mockResolvedValue(mockComment);
+
+      const result = await service.create(createCommentDto);
+
+      expect(result).toEqual(mockComment);
+      expect(mockRepository.create).toHaveBeenCalled();
+      expect(mockRepository.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('findAll', () => {
+    it('devrait retourner un tableau de commentaires', async () => {
+      mockRepository.find.mockResolvedValue([mockComment]);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual([mockComment]);
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        relations: ['member']
+      });
+    });
+  });
+
+  describe('findOne', () => {
+    it('devrait retourner un commentaire par uuid', async () => {
+      mockRepository.findOne.mockResolvedValue(mockComment);
+
+      const result = await service.findOne(mockComment.uuid);
+
+      expect(result).toEqual(mockComment);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { uuid: mockComment.uuid },
+        relations: ['member']
+      });
+    });
+
+    it('devrait lever une exception si le commentaire n\'est pas trouvé', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('non-existant')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('devrait mettre à jour un commentaire', async () => {
+      const updateCommentDto: UpdateCommentDto = {
+        content: 'Updated content'
+      };
+
+      mockRepository.findOne.mockResolvedValue(mockComment);
+      mockRepository.save.mockResolvedValue({ ...mockComment, ...updateCommentDto });
+
+      const result = await service.update(mockComment.uuid, updateCommentDto);
+
+      expect(result).toEqual({ ...mockComment, ...updateCommentDto });
+      expect(mockRepository.save).toHaveBeenCalled();
+    });
+
+    it('devrait lever une exception si le commentaire à mettre à jour n\'existe pas', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.update('non-existant', { content: 'test' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('devrait supprimer un commentaire', async () => {
+      mockRepository.delete.mockResolvedValue({ affected: 1 });
+
+      await service.remove(mockComment.uuid);
+
+      expect(mockRepository.delete).toHaveBeenCalledWith(mockComment.uuid);
+    });
+
+    it('devrait lever une exception si le commentaire à supprimer n\'existe pas', async () => {
+      mockRepository.delete.mockResolvedValue({ affected: 0 });
+
+      await expect(service.remove('non-existant')).rejects.toThrow(NotFoundException);
+    });
+  });
+}); 

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Comment } from './entities/comment.entity';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class CommentsService {
+  constructor(
+    @InjectRepository(Comment)
+    private commentsRepository: Repository<Comment>
+  ) {}
+
+  async create(createCommentDto: CreateCommentDto): Promise<Comment> {
+    const comment = this.commentsRepository.create({
+      uuid: uuidv4(),
+      ...createCommentDto
+    });
+    return await this.commentsRepository.save(comment);
+  }
+
+  async findAll(): Promise<Comment[]> {
+    return await this.commentsRepository.find({
+      relations: ['member']
+    });
+  }
+
+  async findOne(uuid: string): Promise<Comment> {
+    const comment = await this.commentsRepository.findOne({
+      where: { uuid },
+      relations: ['member']
+    });
+    
+    if (!comment) {
+      throw new NotFoundException(`Commentaire avec l'UUID ${uuid} non trouvé`);
+    }
+    
+    return comment;
+  }
+
+  async update(uuid: string, updateCommentDto: UpdateCommentDto): Promise<Comment> {
+    const comment = await this.findOne(uuid);
+    
+    Object.assign(comment, updateCommentDto);
+    
+    return await this.commentsRepository.save(comment);
+  }
+
+  async remove(uuid: string): Promise<void> {
+    const result = await this.commentsRepository.delete(uuid);
+    
+    if (result.affected === 0) {
+      throw new NotFoundException(`Commentaire avec l'UUID ${uuid} non trouvé`);
+    }
+  }
+}

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -1,0 +1,53 @@
+import { IsString, Length, IsUUID, IsIn } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+/**
+ * Data Transfer Object pour la création d'un commentaire
+ * 
+ * @class CreateCommentDto
+ * @description Ce DTO définit la structure et les validations pour les données
+ * nécessaires à la création d'un nouveau commentaire dans le système.
+ */
+export class CreateCommentDto {
+  /**
+   * Contenu du commentaire
+   * @example "Très bon travail sur ce projet !"
+   */
+  @IsString({ message: 'Le contenu doit être une chaîne de caractères' })
+  @Length(1, 1000, { 
+    message: 'Le contenu doit contenir entre $constraint1 et $constraint2 caractères'
+  })
+  @Transform(({ value }) => value?.trim())
+  content: string;
+
+  /**
+   * Statut du commentaire
+   * @example "active"
+   */
+  @IsString({ message: 'Le statut doit être une chaîne de caractères' })
+  @IsIn(['active', 'inactive', 'deleted'], { 
+    message: 'Le statut doit être soit active, inactive ou deleted'
+  })
+  comment_status: string;
+
+  /**
+   * ID de l'utilisateur qui crée le commentaire
+   * @example "123e4567-e89b-12d3-a456-426614174000"
+   */
+  @IsUUID('4', { message: 'L\'ID de l\'utilisateur doit être un UUID valide' })
+  uuid_member: string;
+
+  /**
+   * ID de la ressource concernée par le commentaire
+   * @example "123e4567-e89b-12d3-a456-426614174000"
+   */
+  @IsUUID('4', { message: 'L\'ID de la ressource doit être un UUID valide' })
+  resource_uuid: string;
+
+  /**
+   * ID de l'utilisateur propriétaire du commentaire
+   * @example "123e4567-e89b-12d3-a456-426614174000"
+   */
+  @IsUUID('4', { message: 'L\'ID de l\'utilisateur propriétaire doit être un UUID valide' })
+  user_uuid: string;
+}

--- a/src/comments/dto/update-comment.dto.ts
+++ b/src/comments/dto/update-comment.dto.ts
@@ -1,0 +1,51 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCommentDto } from './create-comment.dto';
+import { IsString, IsOptional, Length, IsIn, IsUUID } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+/**
+ * DTO pour la mise à jour d'un commentaire
+ * 
+ * Hérite de CreateCommentDto avec toutes les propriétés optionnelles
+ * pour permettre des mises à jour partielles.
+ */
+export class UpdateCommentDto extends PartialType(CreateCommentDto) {
+  /**
+   * Nouveau contenu du commentaire
+   * @example "Mise à jour : Excellent travail sur ce projet !"
+   */
+  @IsOptional()
+  @IsString({ message: 'Le contenu doit être une chaîne de caractères' })
+  @Length(1, 1000, { 
+    message: 'Le contenu doit contenir entre $constraint1 et $constraint2 caractères'
+  })
+  @Transform(({ value }) => value?.trim())
+  content?: string;
+
+  /**
+   * Nouveau statut du commentaire
+   * @example "inactive"
+   */
+  @IsOptional()
+  @IsString({ message: 'Le statut doit être une chaîne de caractères' })
+  @IsIn(['active', 'inactive', 'deleted'], { 
+    message: 'Le statut doit être soit active, inactive ou deleted'
+  })
+  comment_status?: string;
+
+  /**
+   * Nouvel ID de la ressource
+   * @example "123e4567-e89b-12d3-a456-426614174000"
+   */
+  @IsOptional()
+  @IsUUID('4', { message: 'L\'ID de la ressource doit être un UUID valide' })
+  resource_uuid?: string;
+
+  /**
+   * Nouvel ID de l'utilisateur propriétaire
+   * @example "123e4567-e89b-12d3-a456-426614174000"
+   */
+  @IsOptional()
+  @IsUUID('4', { message: 'L\'ID de l\'utilisateur propriétaire doit être un UUID valide' })
+  user_uuid?: string;
+}

--- a/src/comments/entities/comment.entity.ts
+++ b/src/comments/entities/comment.entity.ts
@@ -1,0 +1,30 @@
+import { Entity, Column, PrimaryColumn, CreateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Member } from '../../members/entities/member.entity';
+
+@Entity('comments')
+export class Comment {
+  @PrimaryColumn('uuid', { name: 'comment_uuid' })
+  uuid: string;
+
+  @Column({ type: 'text' })
+  content: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  comment_status: string;
+
+  @CreateDateColumn({ type: 'timestamp', name: 'comment_createdAt' })
+  createdAt: Date;
+
+  @Column('uuid')
+  uuid_member: string;
+
+  @Column('uuid')
+  resource_uuid: string;
+
+  @Column('uuid')
+  user_uuid: string;
+
+  @ManyToOne(() => Member)
+  @JoinColumn({ name: 'uuid_member' })
+  member: Member;
+}

--- a/src/tags/dto/create-tag.dto.ts
+++ b/src/tags/dto/create-tag.dto.ts
@@ -1,0 +1,17 @@
+import { IsString, IsNotEmpty, IsOptional, MinLength, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateTagDto {
+  @ApiProperty({ description: 'Nom du tag', minLength: 2, maxLength: 50 })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(2)
+  @MaxLength(50)
+  name: string;
+
+  @ApiPropertyOptional({ description: 'Description du tag', maxLength: 255 })
+  @IsString()
+  @IsOptional()
+  @MaxLength(255)
+  description?: string;
+}

--- a/src/tags/dto/update-tag.dto.ts
+++ b/src/tags/dto/update-tag.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateTagDto } from './create-tag.dto';
+
+export class UpdateTagDto extends PartialType(CreateTagDto) {}

--- a/src/tags/entities/tag.entity.ts
+++ b/src/tags/entities/tag.entity.ts
@@ -1,0 +1,25 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('tags')
+export class Tag {
+  @ApiProperty({ description: 'Identifiant unique du tag' })
+  @PrimaryGeneratedColumn('uuid')
+  uuid: string;
+
+  @ApiProperty({ description: 'Nom du tag' })
+  @Column({ unique: true })
+  name: string;
+
+  @ApiProperty({ description: 'Description du tag' })
+  @Column({ nullable: true })
+  description: string;
+
+  @ApiProperty({ description: 'Date de création du tag' })
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Date de dernière modification du tag' })
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/tags/tags.controller.spec.ts
+++ b/src/tags/tags.controller.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TagsController } from './tags.controller';
+import { TagsService } from './tags.service';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+
+describe('TagsController', () => {
+  let controller: TagsController;
+  let service: TagsService;
+
+  const mockTag = {
+    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    name: 'Test Tag',
+    description: 'Test Description',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockTagsService = {
+    create: vi.fn(),
+    findAll: vi.fn(),
+    findOne: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TagsController],
+      providers: [
+        {
+          provide: TagsService,
+          useValue: mockTagsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<TagsController>(TagsController);
+    service = module.get<TagsService>(TagsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('devrait créer un nouveau tag', async () => {
+      const createTagDto: CreateTagDto = {
+        name: 'Test Tag',
+        description: 'Test Description',
+      };
+
+      mockTagsService.create.mockResolvedValue(mockTag);
+
+      const result = await controller.create(createTagDto);
+
+      expect(result).toEqual(mockTag);
+      expect(mockTagsService.create).toHaveBeenCalledWith(createTagDto);
+    });
+
+    it('devrait propager l\'erreur de conflit', async () => {
+      const createTagDto: CreateTagDto = {
+        name: 'Test Tag',
+        description: 'Test Description',
+      };
+
+      mockTagsService.create.mockRejectedValue(new ConflictException());
+
+      await expect(controller.create(createTagDto)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('devrait retourner un tableau de tags', async () => {
+      mockTagsService.findAll.mockResolvedValue([mockTag]);
+
+      const result = await controller.findAll();
+
+      expect(result).toEqual([mockTag]);
+      expect(mockTagsService.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    it('devrait retourner un tag par son uuid', async () => {
+      mockTagsService.findOne.mockResolvedValue(mockTag);
+
+      const result = await controller.findOne(mockTag.uuid);
+
+      expect(result).toEqual(mockTag);
+      expect(mockTagsService.findOne).toHaveBeenCalledWith(mockTag.uuid);
+    });
+
+    it('devrait propager l\'erreur si le tag n\'existe pas', async () => {
+      mockTagsService.findOne.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.findOne('non-existent-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('devrait mettre à jour un tag', async () => {
+      const updateTagDto: UpdateTagDto = {
+        name: 'Updated Tag',
+      };
+
+      mockTagsService.update.mockResolvedValue({ ...mockTag, ...updateTagDto });
+
+      const result = await controller.update(mockTag.uuid, updateTagDto);
+
+      expect(result).toEqual({ ...mockTag, ...updateTagDto });
+      expect(mockTagsService.update).toHaveBeenCalledWith(mockTag.uuid, updateTagDto);
+    });
+
+    it('devrait propager l\'erreur si le tag n\'existe pas', async () => {
+      mockTagsService.update.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.update('non-existent-id', {})).rejects.toThrow(NotFoundException);
+    });
+
+    it('devrait propager l\'erreur de conflit', async () => {
+      mockTagsService.update.mockRejectedValue(new ConflictException());
+
+      await expect(controller.update(mockTag.uuid, { name: 'Existing Tag' })).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('remove', () => {
+    it('devrait supprimer un tag', async () => {
+      mockTagsService.remove.mockResolvedValue(undefined);
+
+      await controller.remove(mockTag.uuid);
+
+      expect(mockTagsService.remove).toHaveBeenCalledWith(mockTag.uuid);
+    });
+
+    it('devrait propager l\'erreur si le tag n\'existe pas', async () => {
+      mockTagsService.remove.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.remove('non-existent-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+}); 

--- a/src/tags/tags.controller.ts
+++ b/src/tags/tags.controller.ts
@@ -1,0 +1,60 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, HttpStatus, ParseUUIDPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { TagsService } from './tags.service';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+import { Tag } from './entities/tag.entity';
+
+@ApiTags('Tags')
+@Controller('tags')
+export class TagsController {
+  constructor(private readonly tagsService: TagsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Créer un nouveau tag' })
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Tag créé avec succès', type: Tag })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Données invalides' })
+  @ApiResponse({ status: HttpStatus.CONFLICT, description: 'Tag déjà existant' })
+  create(@Body() createTagDto: CreateTagDto): Promise<Tag> {
+    return this.tagsService.create(createTagDto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Récupérer tous les tags' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Liste des tags récupérée avec succès', type: [Tag] })
+  findAll(): Promise<Tag[]> {
+    return this.tagsService.findAll();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer un tag par son ID' })
+  @ApiParam({ name: 'id', description: 'ID du tag', type: 'string' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Tag récupéré avec succès', type: Tag })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Tag non trouvé' })
+  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Tag> {
+    return this.tagsService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Mettre à jour un tag' })
+  @ApiParam({ name: 'id', description: 'ID du tag', type: 'string' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Tag mis à jour avec succès', type: Tag })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Tag non trouvé' })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Données invalides' })
+  @ApiResponse({ status: HttpStatus.CONFLICT, description: 'Tag déjà existant' })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateTagDto: UpdateTagDto,
+  ): Promise<Tag> {
+    return this.tagsService.update(id, updateTagDto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Supprimer un tag' })
+  @ApiParam({ name: 'id', description: 'ID du tag', type: 'string' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Tag supprimé avec succès' })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Tag non trouvé' })
+  remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.tagsService.remove(id);
+  }
+}

--- a/src/tags/tags.module.ts
+++ b/src/tags/tags.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TagsService } from './tags.service';
+import { TagsController } from './tags.controller';
+import { Tag } from './entities/tag.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Tag])],
+  controllers: [TagsController],
+  providers: [TagsService],
+  exports: [TagsService],
+})
+export class TagsModule {}

--- a/src/tags/tags.service.spec.ts
+++ b/src/tags/tags.service.spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TagsService } from './tags.service';
+import { Tag } from './entities/tag.entity';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+
+describe('TagsService', () => {
+  let service: TagsService;
+  let repository: Repository<Tag>;
+
+  const mockTag = {
+    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    name: 'Test Tag',
+    description: 'Test Description',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockRepository = {
+    create: vi.fn(),
+    save: vi.fn(),
+    find: vi.fn(),
+    findOne: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TagsService,
+        {
+          provide: getRepositoryToken(Tag),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TagsService>(TagsService);
+    repository = module.get<Repository<Tag>>(getRepositoryToken(Tag));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('devrait créer un nouveau tag avec succès', async () => {
+      const createTagDto: CreateTagDto = {
+        name: 'Test Tag',
+        description: 'Test Description',
+      };
+
+      mockRepository.create.mockReturnValue(mockTag);
+      mockRepository.save.mockResolvedValue(mockTag);
+
+      const result = await service.create(createTagDto);
+
+      expect(result).toEqual(mockTag);
+      expect(mockRepository.create).toHaveBeenCalledWith(createTagDto);
+      expect(mockRepository.save).toHaveBeenCalledWith(mockTag);
+    });
+
+    it('devrait lever une ConflictException si le tag existe déjà', async () => {
+      const createTagDto: CreateTagDto = {
+        name: 'Test Tag',
+        description: 'Test Description',
+      };
+
+      mockRepository.save.mockRejectedValue({ code: '23505' });
+
+      await expect(service.create(createTagDto)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('devrait retourner un tableau de tags', async () => {
+      mockRepository.find.mockResolvedValue([mockTag]);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual([mockTag]);
+      expect(mockRepository.find).toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    it('devrait retourner un tag par son uuid', async () => {
+      mockRepository.findOne.mockResolvedValue(mockTag);
+
+      const result = await service.findOne(mockTag.uuid);
+
+      expect(result).toEqual(mockTag);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { uuid: mockTag.uuid },
+      });
+    });
+
+    it('devrait lever une NotFoundException si le tag n\'existe pas', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('non-existent-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('devrait mettre à jour un tag avec succès', async () => {
+      const updateTagDto: UpdateTagDto = {
+        name: 'Updated Tag',
+      };
+
+      mockRepository.findOne.mockResolvedValue(mockTag);
+      mockRepository.save.mockResolvedValue({ ...mockTag, ...updateTagDto });
+
+      const result = await service.update(mockTag.uuid, updateTagDto);
+
+      expect(result).toEqual({ ...mockTag, ...updateTagDto });
+      expect(mockRepository.save).toHaveBeenCalled();
+    });
+
+    it('devrait lever une NotFoundException si le tag n\'existe pas', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.update('non-existent-id', {})).rejects.toThrow(NotFoundException);
+    });
+
+    it('devrait lever une ConflictException si le nouveau nom existe déjà', async () => {
+      mockRepository.findOne.mockResolvedValue(mockTag);
+      mockRepository.save.mockRejectedValue({ code: '23505' });
+
+      await expect(service.update(mockTag.uuid, { name: 'Existing Tag' })).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('remove', () => {
+    it('devrait supprimer un tag avec succès', async () => {
+      mockRepository.delete.mockResolvedValue({ affected: 1 });
+
+      await service.remove(mockTag.uuid);
+
+      expect(mockRepository.delete).toHaveBeenCalledWith(mockTag.uuid);
+    });
+
+    it('devrait lever une NotFoundException si le tag n\'existe pas', async () => {
+      mockRepository.delete.mockResolvedValue({ affected: 0 });
+
+      await expect(service.remove('non-existent-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+}); 

--- a/src/tags/tags.service.ts
+++ b/src/tags/tags.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+import { Tag } from './entities/tag.entity';
+
+@Injectable()
+export class TagsService {
+  constructor(
+    @InjectRepository(Tag)
+    private readonly tagRepository: Repository<Tag>,
+  ) {}
+
+  async create(createTagDto: CreateTagDto): Promise<Tag> {
+    try {
+      const tag = this.tagRepository.create(createTagDto);
+      return await this.tagRepository.save(tag);
+    } catch (error) {
+      if (error.code === '23505') {
+        throw new ConflictException('Un tag avec ce nom existe déjà');
+      }
+      throw error;
+    }
+  }
+
+  async findAll(): Promise<Tag[]> {
+    return await this.tagRepository.find();
+  }
+
+  async findOne(uuid: string): Promise<Tag> {
+    const tag = await this.tagRepository.findOne({ where: { uuid } });
+    if (!tag) {
+      throw new NotFoundException(`Tag avec l'ID ${uuid} non trouvé`);
+    }
+    return tag;
+  }
+
+  async update(id: string, updateTagDto: UpdateTagDto): Promise<Tag> {
+    try {
+      const tag = await this.findOne(id);
+      Object.assign(tag, updateTagDto);
+      return await this.tagRepository.save(tag);
+    } catch (error) {
+      if (error.code === '23505') {
+        throw new ConflictException('Un tag avec ce nom existe déjà');
+      }
+      throw error;
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.tagRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Tag avec l'ID ${id} non trouvé`);
+    }
+  }
+}


### PR DESCRIPTION
## Tag module (9 commits) :
_Ticket : 86c21muv6_
- Add tag entity and DTOs for data management
- Implement tag service with CRUD operations
- Create REST API endpoints in tag controller
- Add comprehensive unit tests for service and controller

## Comment module (10 commits) :
_Ticket : 86c23cp42_
- Comments entity with necessary properties and relationships
- CRUD operations in the comments service
- REST endpoints in the comments controller
- Data validation through DTOs (create and update)
- Comprehensive test coverage for both service and controller