### PR TITLE
refactor(86c21mpmv): simplify CreateAnswerDto

### DIFF
--- a/src/answers/dto/create-answer.dto.ts
+++ b/src/answers/dto/create-answer.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, MaxLength, IsUUID } from 'class-validator';
+import { IsString, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateAnswerDto {
@@ -11,11 +11,4 @@ export class CreateAnswerDto {
   @IsString({message: 'Answer content must be a string'})
   @MaxLength(50, {message: 'Answer content must not exceed 50 characters'})
   content: string;
-
-  @ApiProperty({
-    description: 'UUID of the question this answer belongs to',
-    example: '123e4567-e89b-12d3-a456-426614174000'
-  })
-  @IsUUID('4', {message: 'Question UUID must be a valid UUID'})
-  uuidQuestion: string;
 }


### PR DESCRIPTION
T#86c21mpmv

- Remove isMultipleAnswer property and its decorators

- Keep only content property with its validations

- Maintain Swagger documentation for remaining field