### PR TITLE
fix(86c238tg2): fix course relationships, tests and make roles optional

### DIFF
--- a/src/courses/courses.controller.spec.ts
+++ b/src/courses/courses.controller.spec.ts
@@ -48,7 +48,8 @@ describe('CoursesController', () => {
         name: 'Développeur web',
         isCertified: true,
         uuidCategory: '123456789012345678',
-        uuidGuild: '123456789012345678'
+        uuidGuild: '123456789012345678',
+        uuidRole: ''
       };
 
       mockService.create.mockResolvedValue({

--- a/src/courses/courses.controller.ts
+++ b/src/courses/courses.controller.ts
@@ -74,12 +74,12 @@ export class CoursesController {
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiResponse({
-    status: 200,
+    status: HttpStatus.OK,
     description: 'La formation a été trouvée.',
     type: Course,
   })
   @ApiResponse({
-    status: 404,
+    status: HttpStatus.NOT_FOUND,
     description: 'Formation non trouvée.',
   })
   async getByUUID(@Param('uuid_course') uuid_course: string): Promise<Course> {
@@ -97,20 +97,20 @@ export class CoursesController {
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiResponse({
-    status: 200,
+    status: HttpStatus.OK,
     description: 'La formation a été mise à jour avec succès.',
     type: Course,
   })
   @ApiResponse({
-    status: 400,
+    status: HttpStatus.BAD_REQUEST,
     description: 'Données invalides fournies.',
   })
   @ApiResponse({
-    status: 404,
+    status: HttpStatus.NOT_FOUND,
     description: 'Formation non trouvée.',
   })
   @ApiResponse({
-    status: 409,
+    status: HttpStatus.CONFLICT,
     description: 'Le nouveau nom est déjà utilisé par une autre formation.',
   })
   async updateByUUID(
@@ -131,15 +131,15 @@ export class CoursesController {
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiResponse({
-    status: 204,
+    status: HttpStatus.NO_CONTENT,
     description: 'La formation a été supprimée avec succès.',
   })
   @ApiResponse({
-    status: 404,
+    status: HttpStatus.NOT_FOUND,
     description: 'Formation non trouvée.',
   })
   @ApiResponse({
-    status: 400,
+    status: HttpStatus.BAD_REQUEST,
     description: 'Erreur lors de la suppression de la formation.',
   })
   async deleteByUUID(@Param('uuid_course') uuid_course: string): Promise<void> {

--- a/src/courses/courses.controller.ts
+++ b/src/courses/courses.controller.ts
@@ -45,6 +45,24 @@ export class CoursesController {
     return this.coursesService.create(createCourseDto);
   }
 
+  @Get()
+  @ApiOperation({
+      summary: 'Récupérer toutes les formations',
+      description: 'Retourne la liste complète des formations avec leurs relations'
+  })
+  @ApiResponse({
+      status: HttpStatus.OK,
+      description: 'Liste des formations récupérée avec succès',
+      type: [Course]
+  })
+  @ApiResponse({
+      status: HttpStatus.BAD_REQUEST,
+      description: 'Erreur lors de la récupération des formations'
+  })
+  async findAll(): Promise<Course[]> {
+      return this.coursesService.findAll();
+  }
+
   @Get(':uuid_course')
   @ApiOperation({
     summary: 'Récupérer une formation par son UUID',

--- a/src/courses/courses.service.spec.ts
+++ b/src/courses/courses.service.spec.ts
@@ -5,6 +5,7 @@ import { Course } from './entities/course.entity';
 import { Repository } from 'typeorm';
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CreateCourseDto } from './dto/create-course.dto';
 
 describe('CoursesService', () => {
   let service: CoursesService;
@@ -16,8 +17,8 @@ describe('CoursesService', () => {
     isCertified: true,
     createdAt: new Date(),
     updatedAt: null,
-    uuidCategory: '123e4567-e89b-12d3-a456-426614174000',
-    uuidGuild: '123e4567-e89b-12d3-a456-426614174000',
+    uuidCategory: '123456789012345678',
+    uuidGuild: '123456789012345678',
   };
 
   const mockRepository = {
@@ -44,21 +45,37 @@ describe('CoursesService', () => {
   });
 
   describe('create', () => {
-    it('should create a course', async () => {
+    it('should create a course without role', async () => {
       const dto = {
-        uuid: '123e4567-e89b-12d3-a456-426614174000',
-        name: 'Développeur web',
-        isCertified: true,
-        uuidCategory: '123e4567-e89b-12d3-a456-426614174000',
-        uuidGuild: '123456789012345678',
-      };
+          name: 'Développeur web',
+          isCertified: true,
+          uuidCategory: '123456789012345678',
+          uuidGuild: '123456789012345678',
+          uuidRole: ''
+      };  
 
       mockRepository.findOne.mockResolvedValue(null);
       mockRepository.create.mockReturnValue(mockCourse);
       mockRepository.save.mockResolvedValue(mockCourse);
 
       const result = await service.create(dto);
+      expect(result).toEqual(mockCourse);
+  });
 
+  it('should create a course with role', async () => {
+      const dto = {
+          name: 'Développeur web',
+          isCertified: true,
+          uuidCategory: '123456789012345678',
+          uuidGuild: '123456789012345678',
+          uuidRole: '123456789012345678'
+      } as CreateCourseDto;  // Utiliser type assertion
+
+      mockRepository.findOne.mockResolvedValue(null);
+      mockRepository.create.mockReturnValue(mockCourse);
+      mockRepository.save.mockResolvedValue(mockCourse);
+
+      const result = await service.create(dto);
       expect(result).toEqual(mockCourse);
     });
 
@@ -66,9 +83,10 @@ describe('CoursesService', () => {
       const dto = {
         uuid: '123e4567-e89b-12d3-a456-426614174000',
         name: 'Développeur web',
-        uuidCategory: '123e4567-e89b-12d3-a456-426614174000',
+        uuidCategory: '123456789012345678',
         uuidGuild: '123456789012345678',
-        isCertified: true
+        isCertified: true,
+        uuidRole: '123456789012345678'
       };
 
       mockRepository.findOne.mockResolvedValue(mockCourse);

--- a/src/courses/courses.service.ts
+++ b/src/courses/courses.service.ts
@@ -27,33 +27,39 @@ export class CoursesService {
                 throw new ConflictException(`Course with name ${createCourseDto.name} already exists`);
             }
 
-            let savedRole: Role | null = null;
-
-            if (createCourseDto.uuidRole) {
-            const roleData = {
-                uuidRole: createCourseDto.uuidRole,
-                uuidGuild: createCourseDto.uuidGuild,
-                name: createCourseDto.name,
-                memberCount: 0,
-                rolePosition: 0,
-                hoist: false,
-                color: "#000000",
-            };    
-                const newRole = this.roleRepository.create(roleData);
-                savedRole = await this.roleRepository.save(newRole);
-            }
-
             const courseData = {
-                ...createCourseDto,
-                uuidRole: savedRole?.uuidRole || undefined
+                name: createCourseDto.name,
+                isCertified: createCourseDto.isCertified,
+                uuidGuild: createCourseDto.uuidGuild,
+                uuidCategory: createCourseDto.uuidCategory,
             };
-    
+
             const newCourse = this.courseRepository.create(courseData);
             const savedCourse = await this.courseRepository.save(newCourse);
 
+            if (createCourseDto.uuidRole) {
+                const role = await this.roleRepository.findOne({
+                    where: { uuidRole: createCourseDto.uuidRole }
+                });
+
+                if (role) {
+                    await this.courseRepository
+                        .createQueryBuilder()
+                        .relation(Course, "roles")
+                        .of(savedCourse)
+                        .add(role.uuidRole);
+                }
+            }
+
             const courseWithRelations = await this.courseRepository.findOne({
                 where: { uuid: savedCourse.uuid },
-                relations: ['role']
+                relations: {
+                    category: true,
+                    guild: true,
+                    roles: true,
+                    promotions: true,
+                    channels: true
+                }
             });
 
             if (!courseWithRelations) {

--- a/src/courses/courses.service.ts
+++ b/src/courses/courses.service.ts
@@ -19,7 +19,6 @@ export class CoursesService {
 
     async create(createCourseDto: CreateCourseDto): Promise<Course> {
         try {
-            // Vérifier si une formation existe déjà avec le même nom
             const existingCourse = await this.courseRepository.findOne({
                 where: { name: createCourseDto.name },
             });
@@ -27,8 +26,10 @@ export class CoursesService {
             if (existingCourse) {
                 throw new ConflictException(`Course with name ${createCourseDto.name} already exists`);
             }
-    
-            // Créer un rôle associé à la formation
+
+            let savedRole: Role | null = null;
+
+            if (createCourseDto.uuidRole) {
             const roleData = {
                 uuidRole: createCourseDto.uuidRole,
                 uuidGuild: createCourseDto.uuidGuild,
@@ -37,21 +38,19 @@ export class CoursesService {
                 rolePosition: 0,
                 hoist: false,
                 color: "#000000",
-            };
-    
-            const newRole = this.roleRepository.create(roleData);
-            const savedRole = await this.roleRepository.save(newRole);
-    
-            // Créer la formation
+            };    
+                const newRole = this.roleRepository.create(roleData);
+                savedRole = await this.roleRepository.save(newRole);
+            }
+
             const courseData = {
                 ...createCourseDto,
-                uuidRole: savedRole.uuidRole
+                uuidRole: savedRole?.uuidRole || undefined
             };
     
             const newCourse = this.courseRepository.create(courseData);
             const savedCourse = await this.courseRepository.save(newCourse);
 
-            // Charger le cours avec ses relations
             const courseWithRelations = await this.courseRepository.findOne({
                 where: { uuid: savedCourse.uuid },
                 relations: ['role']
@@ -118,7 +117,7 @@ export class CoursesService {
         }
         const result = await this.courseRepository.delete({ uuid });
         if (result.affected === 0) {
-            throw new BadRequestException('Failed to delete course'); // Correction ici
+            throw new BadRequestException('Failed to delete course');
         }
     }
 }

--- a/src/courses/dto/create-course.dto.spec.ts
+++ b/src/courses/dto/create-course.dto.spec.ts
@@ -11,23 +11,21 @@ describe('CreateCourseDto', () => {
         dto.uuidCategory = '123456789012345678';
 
         const errors = await validate(dto);
-        expect(errors).toHaveLength(1);
+        expect(errors).toHaveLength(0);
     });
 
     it('should fail validation for missing required fields', async () => {
         const dto = new CreateCourseDto();
-        // Ne pas définir les champs pour tester la validation des champs requis
 
         const errors = await validate(dto);
         
-        // Vérifier le nombre total d'erreurs (name, isCertified, uuidGuild sont requis)
         expect(errors).toHaveLength(4);
         
-        // Vérifier que chaque champ requis génère une erreur
         const errorProperties = errors.map(error => error.property);
         expect(errorProperties).toContain('name');
         expect(errorProperties).toContain('isCertified');
         expect(errorProperties).toContain('uuidGuild');
+        expect(errorProperties).toContain('uuidCategory');
     });
 
     it('should fail validation for short name', async () => {
@@ -35,9 +33,10 @@ describe('CreateCourseDto', () => {
         dto.name = 'cd';
         dto.isCertified = true;
         dto.uuidGuild = '123456789012345678';
+        dto.uuidCategory = '123456789012345678';
 
         const errors = await validate(dto);
-        expect(errors).toHaveLength(2);
+        expect(errors).toHaveLength(1);
         expect(errors[0].property).toBe('name');
     });
 });

--- a/src/courses/dto/create-course.dto.ts
+++ b/src/courses/dto/create-course.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsBoolean, Length } from "class-validator";
+import { IsString, IsNotEmpty, IsBoolean, Length, Matches, IsOptional, MinLength } from "class-validator";
 import { ApiProperty, IntersectionType, PickType } from "@nestjs/swagger";
 import { PickableDiscordUUIDFields } from "src/utils/pickable-discord-uuid-fields";
 import { PickableDtoFields } from "src/utils/pickable-dto-fields";
@@ -6,7 +6,11 @@ import { PickableDtoFields } from "src/utils/pickable-dto-fields";
 export class CreateCourseDto extends PickType(IntersectionType(PickableDiscordUUIDFields, PickableDtoFields), [
     'name', 
     'uuidGuild', 
-    'uuidRole']) {
+    'uuidRole',
+    'uuidCategory'
+]) {
+    @MinLength(3)
+    name: string;
 
     @ApiProperty({
         description: 'Si la formation est certifiante',
@@ -17,11 +21,6 @@ export class CreateCourseDto extends PickType(IntersectionType(PickableDiscordUU
     @IsBoolean()
     isCertified: boolean;
 
-    @ApiProperty({
-        description: 'UUID de la catégorie',
-        example: '123456789012345678'
-    })
-    @IsString()
-    @Length(17, 19)
-    uuidCategory: string;
+    @IsOptional()
+    uuidRole: string;
 }

--- a/src/courses/entities/course.entity.ts
+++ b/src/courses/entities/course.entity.ts
@@ -6,6 +6,8 @@ import {
   JoinColumn,
   OneToMany,
   ManyToOne,
+  ManyToMany,
+  JoinTable,
 } from 'typeorm';
 import { Category } from '../../categories/entities/category.entity';
 import { Guild } from '../../guilds/entities/guild.entity';
@@ -65,7 +67,7 @@ export class Course {
     description: 'Guilde associée aux formations',
     type: () => Guild,
   })
-  @OneToOne(() => Guild, (guild) => guild.course)
+  @ManyToOne(() => Guild, (guild) => guild.courses)
   @JoinColumn({ name: 'uuid_guild' })
   guild: Guild;
 
@@ -73,10 +75,9 @@ export class Course {
     description: 'UUID unique de la guilde',
     example: '123456789012345678',
   })
-  @Column({ name: 'uuid_guild', type: 'varchar', length: 19, nullable: true})
+  @Column({ name: 'uuid_guild', type: 'varchar', length: 19})
     uuidGuild: string;
   
-
   @ApiProperty({
     description: 'Catégorie associée à la formation',
     example: {
@@ -90,30 +91,35 @@ export class Course {
 
   @ApiProperty({
     description: 'UUID unique de la catégorie',
-    example: '123456789012345678',
-    nullable: true,
+    example: '123456789012345678'
   })
   @Column({
     name: 'uuid_category',
     type: 'varchar',
-    length: 19,
-    nullable: true,
+    length: 19
   })
   uuidCategory: string;
-
+  
   @ApiProperty({
-    description: 'Rôle associé à la formation',
-    example: {
-      uuid: '809809876543210987',
-      name: 'CDA',
-    },
+    description: 'Rôles associés aux formations',
+    type: () => [Role],
+    isArray: true,
+    nullable: true
   })
-  @Column({ name: 'uuid_role', type: 'varchar', length: 19, nullable: true })
-  uuidRole: string;
-
-  @OneToOne(() => Role, (role) => role.course)
-  @JoinColumn({ name: 'uuid_role' })
-  role: Role;
+  
+  @ManyToMany(() => Role, role => role.courses, { nullable: true })
+  @JoinTable({
+    name: 'courses_roles',
+    joinColumns: [{
+        name: 'uuid_course',
+        referencedColumnName: 'uuid'
+    }],
+    inverseJoinColumns: [{
+        name: 'uuid_role',
+        referencedColumnName: 'uuidRole'
+    }]
+  })
+  roles: Role[];
 
   @ApiProperty({
     description: 'Promotions associées à la formation',
@@ -125,7 +131,7 @@ export class Course {
   promotions: Promotion[];
 
   @ApiProperty({
-    description: 'Chaînes associées à la formation',
+    description: 'Channels associés à la formation',
     type: () => [Channel],
     isArray: true,
     nullable: true,

--- a/src/guilds/entities/guild.entity.ts
+++ b/src/guilds/entities/guild.entity.ts
@@ -66,11 +66,11 @@ export class Guild {
   promotions: Promotion[];
 
   @ApiProperty({
-    description: 'Formation associée à la guilde',
-    type: () => Course
+    description: 'Formations associées à la guilde',
+    type: () => [Course]
   })
-  @OneToOne(() => Course, course => course.guild)
-  course: Course;
+  @OneToMany(() => Course, course => course.guild)
+  courses: Course[];
 
   @ApiProperty({
     description: 'Rôles de la guilde',

--- a/src/roles/entities/role.entity.ts
+++ b/src/roles/entities/role.entity.ts
@@ -88,12 +88,13 @@ export class Role {
   members: Member[];
   
   @ApiProperty({
-    description: 'Formation associée à un role',
+    description: 'Formations associées aux roles',
     type: () => [Course],
-    isArray: true
+    isArray: true,
+    nullable: true
   })
-  @OneToOne(() => Course, course => course.role)
-  course: Course;
+  @ManyToMany(() => Course, course => course.roles, { nullable: true })
+  courses: Course[];
 
   @OneToOne(() => Campus, campus => campus.role)
   campus: Campus;

--- a/src/utils/pickable-discord-uuid-fields.ts
+++ b/src/utils/pickable-discord-uuid-fields.ts
@@ -30,7 +30,7 @@ export class PickableDiscordUUIDFields {
     description: 'Identifiant unique de category (Snowflake)',
     minLength: 17,
     maxLength: 19,
-    example: '726798891974243359',
+    example: '123456789012345678',
   })
   @IsString()
   @Matches(/^\d+$/)


### PR DESCRIPTION
- Implement and fix relationships between courses and other entities (guilds, categories, roles, channels, promotions)
- Make roles optional in course creation and update operations.
- Fix courses service, controller and their respective tests to handle the new relationships correctly.
- Refactor httpstatus when it wasn't implemented